### PR TITLE
correct path to kernel patch in install guide

### DIFF
--- a/site/install.txt
+++ b/site/install.txt
@@ -609,7 +609,7 @@ read the link (and the patch itself for more information). @/news/20200509a
     |                                                                          |
     |   TIP: A patch can be applied to remove this requirement.                |
     |        - @/wiki/kernel/config#5.0                                        |
-    |        - /usr/share/doc/wiki/kernel/patches/kernel-no-perl.patch         |
+    |        - /usr/share/doc/kiss/wiki/kernel/patches/kernel-no-perl.patch    |
     |                                                                          |
     +--------------------------------------------------------------------------+
 


### PR DESCRIPTION
Corrects the path to the offline kiss wiki which is mentioned when referencing the `kernel-no-perl.patch`.